### PR TITLE
Release 0.0.3 version of HUGS Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
+> ![WARNING]
+> HUGS Helm Chart is subject to changes before the 0.1.0 release!
+
 ## Installing the Chart
 
 To add the chart from the current repository you need to run:
@@ -24,7 +27,8 @@ $ helm install hugs-demo hugs/hugs \
     -f aws/eks-values.yaml \
     --set image.registry="XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com" \
     --set image.repository="hugging-face" \
-    --set image.name="nvidia-meta-llama-meta-llama-3.1-8b-instruct"
+    --set image.name="nvidia-meta-llama-meta-llama-3.1-8b-instruct" \
+    --set image.tag="0.1.0"
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png" width="200" alt="HUGS Logo">
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
@@ -24,7 +24,7 @@ $ helm install hugs-demo hugs/hugs \
     -f aws/eks-values.yaml \
     --set image.registry="XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com" \
     --set image.repository="hugging-face" \
-    --set image.model="nvidia-meta-llama-meta-llama-3.1-8b-instruct"
+    --set image.name="nvidia-meta-llama-meta-llama-3.1-8b-instruct"
 ```
 
 > [!NOTE]

--- a/aws/README.md
+++ b/aws/README.md
@@ -170,6 +170,7 @@ helm install $DEPLOYMENT_NAME hugs/hugs \
     --set image.registry="XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com" \
     --set image.repository="hugging-face" \
     --set image.name="nvidia-meta-llama-meta-llama-3.1-8b-instruct" \
+    --set image.tag="0.1.0" \
     --set serviceAccountName=$SERVICE_ACCOUNT_NAME \
     --set nodeSelector."eks\.amazonaws\.com/nodegroup"=$NODE_GROUP_NAME
 ```

--- a/aws/README.md
+++ b/aws/README.md
@@ -169,7 +169,7 @@ helm install $DEPLOYMENT_NAME hugs/hugs \
     -f eks-values.yaml \
     --set image.registry="XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com" \
     --set image.repository="hugging-face" \
-    --set image.model="nvidia-meta-llama-meta-llama-3.1-8b-instruct" \
+    --set image.name="nvidia-meta-llama-meta-llama-3.1-8b-instruct" \
     --set serviceAccountName=$SERVICE_ACCOUNT_NAME \
     --set nodeSelector."eks\.amazonaws\.com/nodegroup"=$NODE_GROUP_NAME
 ```

--- a/aws/eks-values.yaml
+++ b/aws/eks-values.yaml
@@ -5,7 +5,7 @@ image:
   repository: hugging-face
   name: nvidia-meta-llama-meta-llama-3.1-8b-instruct
   pullPolicy: Always
-  tag: latest
+  tag: 0.1.0
 
 serviceAccountName: hugs-service-account
 

--- a/aws/eks-values.yaml
+++ b/aws/eks-values.yaml
@@ -1,3 +1,5 @@
+# numReplicas: 1
+
 image:
   registry: # Add your custom HUGS Registry here as XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com
   repository: hugging-face
@@ -27,6 +29,26 @@ securityContext:
 #   PORT: "80"
 env:
   AWS_MARKETPLACE_PRODUCT_CODE: 4qd427bqyuzyhn5st1v7x40oq
+
+livenessProbe:
+  enabled: true
+  # You may want to increase the initialDelaySeconds for the bigger LLMs as Llama 3.1 405B
+  # since the download will take longer and the default delay may not be enough for the
+  # download to be completed
+  # initialDelaySeconds: 360
+  # periodSeconds: 15
+  # timeoutSeconds: 5
+  # failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  # You may want to increase the initialDelaySeconds for the bigger LLMs as Llama 3.1 405B
+  # since the download will take longer and the default delay may not be enough for the
+  # download to be completed
+  # initialDelaySeconds: 360
+  # periodSeconds: 30
+  # timeoutSeconds: 5
+  # failureThreshold: 3
 
 service:
   type: NodePort

--- a/aws/eks-values.yaml
+++ b/aws/eks-values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: # Add your custom HUGS Registry here as XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com
   repository: hugging-face
-  model: nvidia-meta-llama-meta-llama-3.1-8b-instruct
+  name: nvidia-meta-llama-meta-llama-3.1-8b-instruct
   pullPolicy: Always
   tag: latest
 

--- a/aws/eks-values.yaml
+++ b/aws/eks-values.yaml
@@ -27,8 +27,6 @@ securityContext:
 # update the service, readiness, and liveness ports too.
 # env:
 #   PORT: "80"
-env:
-  AWS_MARKETPLACE_PRODUCT_CODE: 4qd427bqyuzyhn5st1v7x40oq
 
 livenessProbe:
   enabled: true

--- a/charts/hugs/Chart.yaml
+++ b/charts/hugs/Chart.yaml
@@ -2,6 +2,6 @@ name: hugs
 description: Helm Chart for Hugging Face Generative AI Services (HUGS)
 icon: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png
 type: application
-version: 0.0.2
+version: 0.0.3
 apiVersion: v2
 appVersion: "1.16.0"

--- a/charts/hugs/index.yaml
+++ b/charts/hugs/index.yaml
@@ -3,9 +3,9 @@ entries:
   hugs:
     - apiVersion: v2
       appVersion: 1.16.0
-      created: "2024-10-21T09:53:48.043353+02:00"
+      created: "2024-10-22T10:30:39.190715+02:00"
       description: Helm Chart for Hugging Face Generative AI Services (HUGS)
-      digest: 195023e3eef6cd3f99127437ba6ff4d6e7bb096230ea6e3c53b4f1bdf4557968
+      digest: f7445118423e982a8f7f1404005b0f8b78e9c42f08c45901afb4f222b8a6f08a
       icon: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png
       name: hugs
       type: application
@@ -14,7 +14,7 @@ entries:
       version: 0.0.3
     - apiVersion: v2
       appVersion: 1.16.0
-      created: "2024-10-21T09:53:48.042253+02:00"
+      created: "2024-10-22T10:30:39.188954+02:00"
       description: Helm Chart for Hugging Face Generative AI Services (HUGS)
       digest: 0c61117d75132e8734ca6e3f7938ff3cd17276d244c02626f61c48b11da71b5e
       icon: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png
@@ -25,7 +25,7 @@ entries:
       version: 0.0.2
     - apiVersion: v2
       appVersion: 1.16.0
-      created: "2024-10-21T09:53:48.041335+02:00"
+      created: "2024-10-22T10:30:39.188059+02:00"
       description: Helm chart for Hugging Face Generative AI Services (HUGS)
       digest: 31d3f14e70547a246e61803faeea9d30888eabee796d7cfe2b7f1f881075ceea
       icon: https://huggingface.co/front/assets/huggingface_logo-noborder.svg
@@ -34,4 +34,4 @@ entries:
       urls:
         - https://github.com/huggingface/hugs-helm-chart/releases/download/0.0.1/hugs-0.0.1.tgz
       version: 0.0.1
-generated: "2024-10-21T09:53:48.040768+02:00"
+generated: "2024-10-22T10:30:39.187477+02:00"

--- a/charts/hugs/index.yaml
+++ b/charts/hugs/index.yaml
@@ -3,7 +3,18 @@ entries:
   hugs:
     - apiVersion: v2
       appVersion: 1.16.0
-      created: "2024-10-18T14:59:12.947806+02:00"
+      created: "2024-10-21T09:53:48.043353+02:00"
+      description: Helm Chart for Hugging Face Generative AI Services (HUGS)
+      digest: 195023e3eef6cd3f99127437ba6ff4d6e7bb096230ea6e3c53b4f1bdf4557968
+      icon: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png
+      name: hugs
+      type: application
+      urls:
+        - https://github.com/huggingface/hugs-helm-chart/releases/download/0.0.3/hugs-0.0.3.tgz
+      version: 0.0.3
+    - apiVersion: v2
+      appVersion: 1.16.0
+      created: "2024-10-21T09:53:48.042253+02:00"
       description: Helm Chart for Hugging Face Generative AI Services (HUGS)
       digest: 0c61117d75132e8734ca6e3f7938ff3cd17276d244c02626f61c48b11da71b5e
       icon: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hugs/hugs-purple-no-bg.png
@@ -14,7 +25,7 @@ entries:
       version: 0.0.2
     - apiVersion: v2
       appVersion: 1.16.0
-      created: "2024-10-18T14:59:12.946878+02:00"
+      created: "2024-10-21T09:53:48.041335+02:00"
       description: Helm chart for Hugging Face Generative AI Services (HUGS)
       digest: 31d3f14e70547a246e61803faeea9d30888eabee796d7cfe2b7f1f881075ceea
       icon: https://huggingface.co/front/assets/huggingface_logo-noborder.svg
@@ -23,4 +34,4 @@ entries:
       urls:
         - https://github.com/huggingface/hugs-helm-chart/releases/download/0.0.1/hugs-0.0.1.tgz
       version: 0.0.1
-generated: "2024-10-18T14:59:12.946052+02:00"
+generated: "2024-10-21T09:53:48.040768+02:00"

--- a/charts/hugs/templates/_helpers.tpl
+++ b/charts/hugs/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Build the image URI from registry, repository, model, and tag
+Build the image URI from registry, repository, name, and tag
 */}}
 {{- define "hugs.image_uri" -}}
 {{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.name .Values.image.tag | trimSuffix "/" }}

--- a/charts/hugs/templates/_helpers.tpl
+++ b/charts/hugs/templates/_helpers.tpl
@@ -65,5 +65,5 @@ Create the name of the service account to use
 Build the image URI from registry, repository, model, and tag
 */}}
 {{- define "hugs.image_uri" -}}
-{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.model .Values.image.tag | trimSuffix "/" }}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.name .Values.image.tag | trimSuffix "/" }}
 {{- end }}

--- a/charts/hugs/templates/deployment.yaml
+++ b/charts/hugs/templates/deployment.yaml
@@ -45,22 +45,26 @@ spec:
             - name: http
               containerPort: {{ $.Values.env.PORT | default 80 | int }}
               protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ $.Values.env.PORT | default 80 | int }}
-            initialDelaySeconds: 360
-            periodSeconds: 15
-            timeoutSeconds: 5
-            failureThreshold: 3
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /health
               port: {{ $.Values.env.PORT | default 80 | int }}
-            initialDelaySeconds: 360
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 360 }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 30 }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ $.Values.env.PORT | default 80 | int }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 360 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 15 }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.env }}

--- a/charts/hugs/templates/tests/test-completions.yaml
+++ b/charts/hugs/templates/tests/test-completions.yaml
@@ -22,9 +22,12 @@ spec:
       command:
         - /bin/sh
         - -c
-        - |
-          curl -v -f \
-            -H "Content-Type: application/json" \
-            -d '{"messages":[{"role":"user","content":"What'"'"'s Deep Learning?"}],"max_tokens":10,"stream":false}' \
-            http://{{ include "hugs.fullname" . }}:{{ .Values.service.port }}/v1/chat/completions
+        - >
+          curl -v -f --max-time 10
+          --retry 10
+          --retry-delay 30
+          --retry-all-errors
+          -H "Content-Type: application/json"
+          -d '{"messages":[{"role":"user","content":"What is Deep Learning?"}],"max_tokens":10,"stream":false}'
+          http://{{ include "hugs.fullname" . }}:{{ .Values.service.port }}/v1/chat/completions
   restartPolicy: Never

--- a/charts/hugs/templates/tests/test-health.yaml
+++ b/charts/hugs/templates/tests/test-health.yaml
@@ -22,5 +22,10 @@ spec:
       command:
         - /bin/sh
         - -c
-        - curl -v -f --max-time 10 http://{{ include "hugs.fullname" . }}:{{ .Values.service.port }}/health
+        - >
+          curl -v -f --max-time 10
+          --retry 10
+          --retry-delay 30
+          --retry-all-errors
+          http://{{ include "hugs.fullname" . }}:{{ .Values.service.port }}/health
   restartPolicy: Never

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -26,6 +26,26 @@ env: {}
 # update the service, readiness, and liveness ports too.
 #   PORT: "80"
 
+livenessProbe:
+  enabled: true
+  # You may want to increase the initialDelaySeconds for the bigger LLMs as Llama 3.1 405B
+  # since the download will take longer and the default delay may not be enough for the
+  # download to be completed
+  # initialDelaySeconds: 360
+  # periodSeconds: 15
+  # timeoutSeconds: 5
+  # failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  # You may want to increase the initialDelaySeconds for the bigger LLMs as Llama 3.1 405B
+  # since the download will take longer and the default delay may not be enough for the
+  # download to be completed
+  # initialDelaySeconds: 360
+  # periodSeconds: 30
+  # timeoutSeconds: 5
+  # failureThreshold: 3
+
 service:
   type: NodePort
   port: 80

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: # Add the HUGS Registry that you subscribed to
   repository: # Add the HUGS Repository where the container is hosted in
-  model: # Add the name of the HUGS container which matches the model to be served
+  name: # Add the name of the HUGS container image
   pullPolicy: Always
   tag: latest
 

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -1,3 +1,5 @@
+# numReplicas: 1
+
 image:
   registry: # Add the HUGS Registry that you subscribed to
   repository: # Add the HUGS Repository where the container is hosted in

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: # Add the HUGS Repository where the container is hosted in
   name: # Add the name of the HUGS container image
   pullPolicy: Always
-  tag: latest
+  tag: 0.1.0
 
 # serviceAccountName: hugs-service-account
 


### PR DESCRIPTION
## Description

This PR updates the Helm Chart with the following:

- Rename `image.model` to `image.name` since its more clear
- Add `livenessProbe` and `readinessProbe` in `values.yaml` with `enable` and allowing to modify the defaults for the timeouts (useful when using HUGS to serve and deploy large LLMs such as Llama 3.1 405B, as the defaults would make the deployment fail)
- Update test suite to use `--retry` to prevent the tests from failing due to the pod not being ready when triggered `helm test` right after `helm install` 