### PR TITLE
Add custom tolerations support

### DIFF
--- a/charts/hugs/templates/deployment.yaml
+++ b/charts/hugs/templates/deployment.yaml
@@ -30,9 +30,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       tolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
+        {{- if .Values.tolerations }}
+          {{- toYaml .Values.tolerations | nindent 8 }}
+        {{- else }}
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext }}

--- a/charts/hugs/templates/deployment.yaml
+++ b/charts/hugs/templates/deployment.yaml
@@ -32,10 +32,6 @@ spec:
       tolerations:
         {{- if .Values.tolerations }}
           {{- toYaml .Values.tolerations | nindent 8 }}
-        {{- else }}
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -85,6 +85,9 @@ nodeSelector:
   {}
   # eks.amazonaws.com/nodegroup: hugs-node-group
 
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 autoscaling:
   enabled: false
   # minReplicas: 1

--- a/charts/hugs/values.yaml
+++ b/charts/hugs/values.yaml
@@ -85,8 +85,9 @@ nodeSelector:
   {}
   # eks.amazonaws.com/nodegroup: hugs-node-group
 
-## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
+# https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations:
+  {}
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Custom tolerations support increases the chart's flexibility, allowing deployment to nodes with different tolerations than the defaults.